### PR TITLE
fix: fix handling of trace array for PyPSA ≥ 1.2.3

### DIFF
--- a/src/pypsa_explorer/callbacks/visualizations.py
+++ b/src/pypsa_explorer/callbacks/visualizations.py
@@ -47,7 +47,9 @@ def register_visualization_callbacks(app, networks: dict[str, pypsa.Network]) ->
             else:
                 axis_key = "yaxis"
 
-            values = getattr(trace, "y", []) or []
+            values = getattr(trace, "y", None)
+            if values is None:
+                continue
             try:
                 iterator = list(values)
             except TypeError:


### PR DESCRIPTION
This PR fixes a crash in the bar-chart views (energy balance totals, capacity totals, CAPEX, OPEX) for PyPSA >= 1.2.3.

Since 1.2.3, PyPSA merges same-column bar traces into one trace with a multi-element y. _compute_bar_chart_height() which forces a bool() on the trace array and raises "The truth value of an array with more than one element is ambiguous". 

It now reads the attribute with a None default and skips traces without one.

Generative AI was used to assist with this PR. All content has been reviewed, verified, and is the responsibility of the author.